### PR TITLE
Fix selector to get actual css files

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function getCss(cb) {
 		var ret = [];
 		var $ = cheerio.load(data);
 
-		$('link[href*="assets/github"]').each(function (i, el) {
+		$('link[href$=".css"]').each(function (i, el) {
 			ret.push(el.attribs.href);
 		});
 


### PR DESCRIPTION
Now `generate-github-markdown-css` couldn't generate CSS because:

- GitHub has `<link as="script" href="assets/github-*.js" rel="preload" />` for JavaScript preloading
- Styles are separated into `assets/frameworks-*.css` and `assets/github-*.css`

`getCss()` should check `.css` extension to detect the actual CSS files.
I updated the selector.