### PR TITLE
Require Node.js 8, include a code snippet in the fixture, and change how we generate the HTML

### DIFF
--- a/fixture.md
+++ b/fixture.md
@@ -12,6 +12,9 @@
 <img src="image.png" width="182" align="right">
 
 
+### Code snippet
+
+https://github.com/sindresorhus/generate-github-markdown-css/blob/6d6a328dc9706d4e6f1bcc524ed1ad1b0448a3ea/index.js#L25-L28
 
 ---
 
@@ -658,7 +661,7 @@ Multiple paragraphs:
 
 	Item 2. graf two. The quick brown fox jumped over the lazy dog's
 	back.
-	
+
 2.	Item 2.
 
 3.	Item 3.
@@ -972,7 +975,7 @@ wrap the text and put a `>` before every line:
     > This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
     > consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
     > Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
-    > 
+    >
     > Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
     > id sem consectetuer libero luctus adipiscing.
 
@@ -999,12 +1002,12 @@ Blockquotes can contain other Markdown elements, including headers, lists,
 and code blocks:
 
 	> ## This is a header.
-	> 
+	>
 	> 1.   This is the first list item.
 	> 2.   This is the second list item.
-	> 
+	>
 	> Here's some example code:
-	> 
+	>
 	>     return shell_exec("echo $input | $markdown_script");
 
 Any decent text editor should make email-style quoting easy. For
@@ -1249,7 +1252,7 @@ following lines will produce a horizontal rule:
     ***
 
     *****
-	
+
     - - -
 
     ---------------------------------------
@@ -1350,7 +1353,7 @@ multiple words in the link text:
 	Visit [Daring Fireball][] for more information.
 
 And then define the link:
-	
+
 	[Daring Fireball]: http://daringfireball.net/
 
 Link definitions can be placed anywhere in your Markdown document. I
@@ -1474,13 +1477,13 @@ one after the opening, one before the closing. This allows you to place
 literal backtick characters at the beginning or end of a code span:
 
 	A single backtick in a code span: `` ` ``
-	
+
 	A backtick-delimited string in a code span: `` `foo` ``
 
 will produce:
 
 	<p>A single backtick in a code span: <code>`</code></p>
-	
+
 	<p>A backtick-delimited string in a code span: <code>`foo`</code></p>
 
 With a code span, ampersands and angle brackets are encoded as HTML
@@ -1551,7 +1554,7 @@ use regular HTML `<img>` tags.
 Markdown supports a shortcut style for creating "automatic" links for URLs and email addresses: simply surround the URL or email address with angle brackets. What this means is that if you want to show the actual text of a URL or email address, and also have it be a clickable link, you can do this:
 
     <http://example.com/>
-    
+
 Markdown will turn this into:
 
     <a href="http://example.com/">http://example.com/</a>
@@ -1633,7 +1636,7 @@ This is the [simple case].
 This one has a [line
 break].
 
-This one has a [line 
+This one has a [line
 break] with a line-ending space.
 
 [line break]: /foo
@@ -1692,12 +1695,12 @@ Code block:
 
 Just plain comment, with trailing spaces on the line:
 
-<!-- foo -->   
+<!-- foo -->
 
 Code:
 
 	<hr />
-	
+
 Hr's:
 
 <hr>
@@ -1706,11 +1709,11 @@ Hr's:
 
 <hr />
 
-<hr>   
+<hr>
 
-<hr/>  
+<hr/>
 
-<hr /> 
+<hr />
 
 <hr class="foo" id="bar" />
 

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ const cleanupCss = str => {
 		}
 
 		if (el.type === 'rule') {
-			if (/::-webkit-validation|[:-]placeholder$|^\.integrations-slide-content|^\.prose-diff|@font-face|^button::|^article$|^\.plan-|^\.plans-|^\.repo-config-option|\.site-search|^::-webkit-file-upload-button$|^input::-webkit-outer-spin-button$/.test(el.selectors[0])) {
+			if (/::-webkit-validation|[:-]placeholder$|^\.placeholder-box$|^\.integrations-slide-content|^\.prose-diff|@font-face|^button::|^article$|^\.plan-|^\.plans-|^\.repo-config-option|\.site-search|^::-webkit-file-upload-button$|^input::-webkit-outer-spin-button$/.test(el.selectors[0])) {
 				return false;
 			}
 
@@ -102,5 +102,5 @@ module.exports = () =>
 		getRenderedFixture(),
 		getCSS()
 	])
-	.then(x => uncssP(x[0], {stylesheets: x[1], ignore: [/^\.pl/]}))
+	.then(x => uncssP(x[0], {stylesheets: x[1], ignore: [/^\.pl|^\.tab-size/]}))
 	.then(cleanupCss);

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ const got = require('got');
 const cheerio = require('cheerio');
 const uncss = require('uncss');
 const pify = require('pify');
+const fs = require('fs');
 
 const uncssP = pify(uncss);
-const fixtureURL = 'https://github.com/sindresorhus/generate-github-markdown-css/blob/master/fixture.md';
 
 const getCSS = () => got('https://github.com').then(response => {
 	const ret = [];
@@ -22,10 +22,13 @@ const getCSS = () => got('https://github.com').then(response => {
 	return ret;
 });
 
-const getRenderedFixture = () => got(fixtureURL).then(response => {
-	const $ = cheerio.load(response.body);
-	return $('.markdown-body').parent().html();
-});
+const getRenderedFixture = () => got.post('https://api.github.com/markdown', {
+	headers: {'Content-Type': 'application/json', 'User-Agent': 'generate-github-markdown-css'},
+	body: JSON.stringify({
+		mode: 'gfm', context: 'sindresorhus/generate-github-markdown-css',
+		text: fs.readFileSync('./fixture.md').toString()
+	})
+}).then(response => `<div class="markdown-body">\n${response.body}\n</div>`);
 
 const cleanupCss = str => {
 	const css = require('css');
@@ -51,17 +54,6 @@ const cleanupCss = str => {
 			// Remove `body` from `body, input {}`
 			if (el.selectors[0] === 'body' && el.selectors[1] === 'input') {
 				el.selectors.shift();
-			}
-
-			// Rename the .octoicons font
-			if (el.selectors[0] === '.octicon') {
-				el.declarations = el.declarations.map(el => {
-					if (el.property === 'font') {
-						el.value += '-link';
-					}
-
-					return el;
-				});
 			}
 
 			if (el.selectors.length === 1 && /^(?:html|body)$/.test(el.selectors[0])) {
@@ -98,7 +90,7 @@ const cleanupCss = str => {
 		declarations: mdBodyProps
 	});
 
-	return `@font-face {\n  font-family: octicons-link;\n  src: url(data:font/woff;charset=utf-8;base64,d09GRgABAAAAAAZwABAAAAAACFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEU0lHAAAGaAAAAAgAAAAIAAAAAUdTVUIAAAZcAAAACgAAAAoAAQAAT1MvMgAAAyQAAABJAAAAYFYEU3RjbWFwAAADcAAAAEUAAACAAJThvmN2dCAAAATkAAAABAAAAAQAAAAAZnBnbQAAA7gAAACyAAABCUM+8IhnYXNwAAAGTAAAABAAAAAQABoAI2dseWYAAAFsAAABPAAAAZwcEq9taGVhZAAAAsgAAAA0AAAANgh4a91oaGVhAAADCAAAABoAAAAkCA8DRGhtdHgAAAL8AAAADAAAAAwGAACfbG9jYQAAAsAAAAAIAAAACABiATBtYXhwAAACqAAAABgAAAAgAA8ASm5hbWUAAAToAAABQgAAAlXu73sOcG9zdAAABiwAAAAeAAAAME3QpOBwcmVwAAAEbAAAAHYAAAB/aFGpk3jaTY6xa8JAGMW/O62BDi0tJLYQincXEypYIiGJjSgHniQ6umTsUEyLm5BV6NDBP8Tpts6F0v+k/0an2i+itHDw3v2+9+DBKTzsJNnWJNTgHEy4BgG3EMI9DCEDOGEXzDADU5hBKMIgNPZqoD3SilVaXZCER3/I7AtxEJLtzzuZfI+VVkprxTlXShWKb3TBecG11rwoNlmmn1P2WYcJczl32etSpKnziC7lQyWe1smVPy/Lt7Kc+0vWY/gAgIIEqAN9we0pwKXreiMasxvabDQMM4riO+qxM2ogwDGOZTXxwxDiycQIcoYFBLj5K3EIaSctAq2kTYiw+ymhce7vwM9jSqO8JyVd5RH9gyTt2+J/yUmYlIR0s04n6+7Vm1ozezUeLEaUjhaDSuXHwVRgvLJn1tQ7xiuVv/ocTRF42mNgZGBgYGbwZOBiAAFGJBIMAAizAFoAAABiAGIAznjaY2BkYGAA4in8zwXi+W2+MjCzMIDApSwvXzC97Z4Ig8N/BxYGZgcgl52BCSQKAA3jCV8CAABfAAAAAAQAAEB42mNgZGBg4f3vACQZQABIMjKgAmYAKEgBXgAAeNpjYGY6wTiBgZWBg2kmUxoDA4MPhGZMYzBi1AHygVLYQUCaawqDA4PChxhmh/8ODDEsvAwHgMKMIDnGL0x7gJQCAwMAJd4MFwAAAHjaY2BgYGaA4DAGRgYQkAHyGMF8NgYrIM3JIAGVYYDT+AEjAwuDFpBmA9KMDEwMCh9i/v8H8sH0/4dQc1iAmAkALaUKLgAAAHjaTY9LDsIgEIbtgqHUPpDi3gPoBVyRTmTddOmqTXThEXqrob2gQ1FjwpDvfwCBdmdXC5AVKFu3e5MfNFJ29KTQT48Ob9/lqYwOGZxeUelN2U2R6+cArgtCJpauW7UQBqnFkUsjAY/kOU1cP+DAgvxwn1chZDwUbd6CFimGXwzwF6tPbFIcjEl+vvmM/byA48e6tWrKArm4ZJlCbdsrxksL1AwWn/yBSJKpYbq8AXaaTb8AAHja28jAwOC00ZrBeQNDQOWO//sdBBgYGRiYWYAEELEwMTE4uzo5Zzo5b2BxdnFOcALxNjA6b2ByTswC8jYwg0VlNuoCTWAMqNzMzsoK1rEhNqByEyerg5PMJlYuVueETKcd/89uBpnpvIEVomeHLoMsAAe1Id4AAAAAAAB42oWQT07CQBTGv0JBhagk7HQzKxca2sJCE1hDt4QF+9JOS0nbaaYDCQfwCJ7Au3AHj+LO13FMmm6cl7785vven0kBjHCBhfpYuNa5Ph1c0e2Xu3jEvWG7UdPDLZ4N92nOm+EBXuAbHmIMSRMs+4aUEd4Nd3CHD8NdvOLTsA2GL8M9PODbcL+hD7C1xoaHeLJSEao0FEW14ckxC+TU8TxvsY6X0eLPmRhry2WVioLpkrbp84LLQPGI7c6sOiUzpWIWS5GzlSgUzzLBSikOPFTOXqly7rqx0Z1Q5BAIoZBSFihQYQOOBEdkCOgXTOHA07HAGjGWiIjaPZNW13/+lm6S9FT7rLHFJ6fQbkATOG1j2OFMucKJJsxIVfQORl+9Jyda6Sl1dUYhSCm1dyClfoeDve4qMYdLEbfqHf3O/AdDumsjAAB42mNgYoAAZQYjBmyAGYQZmdhL8zLdDEydARfoAqIAAAABAAMABwAKABMAB///AA8AAQAAAAAAAAAAAAAAAAABAAAAAA==) format('woff');\n}\n\n${css.stringify(style)}`;
+	return css.stringify(style);
 };
 
 module.exports = () =>

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const cheerio = require('cheerio');
 const uncss = require('uncss');
 const pify = require('pify');
 const fs = require('fs');
+const path = require('path');
 
 const uncssP = pify(uncss);
 
@@ -30,7 +31,7 @@ const getRenderedFixture = () => got.post('https://api.github.com/markdown', {
 	body: JSON.stringify({
 		mode: 'gfm',
 		context: 'sindresorhus/generate-github-markdown-css',
-		text: fs.readFileSync('./fixture.md', 'utf8')
+		text: fs.readFileSync(path.join(__dirname, 'fixture.md'), 'utf8')
 	})
 }).then(response => `<div class="markdown-body">\n${response.body}\n</div>`);
 

--- a/index.js
+++ b/index.js
@@ -23,10 +23,14 @@ const getCSS = () => got('https://github.com').then(response => {
 });
 
 const getRenderedFixture = () => got.post('https://api.github.com/markdown', {
-	headers: {'Content-Type': 'application/json', 'User-Agent': 'generate-github-markdown-css'},
+	headers: {
+		'content-type': 'application/json',
+		'user-agent': 'generate-github-markdown-css'
+	},
 	body: JSON.stringify({
-		mode: 'gfm', context: 'sindresorhus/generate-github-markdown-css',
-		text: fs.readFileSync('./fixture.md').toString()
+		mode: 'gfm',
+		context: 'sindresorhus/generate-github-markdown-css',
+		text: fs.readFileSync('./fixture.md', 'utf8')
 	})
 }).then(response => `<div class="markdown-body">\n${response.body}\n</div>`);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-github-markdown-css",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Generate the CSS for github-markdown-css",
   "license": "MIT",
   "repository": "sindresorhus/generate-github-markdown-css",
@@ -14,13 +14,17 @@
       "name": "Benjamin Tan",
       "email": "demoneaux@gmail.com",
       "url": "d10.github.io"
+    },
+    {
+      "name": "Piotr Kaminski",
+      "email": "piotr@ideanest.com"
     }
   ],
   "bin": {
     "github-markdown-css": "cli.js"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "scripts": {
     "test": "xo && ava"
@@ -42,10 +46,10 @@
   "dependencies": {
     "cheerio": "^0.22.0",
     "css": "^2.0.0",
-    "got": "^7.1.0",
-    "meow": "^3.3.0",
-    "pify": "^3.0.0",
-    "uncss": "^0.15.0"
+    "got": "^9.0.0",
+    "meow": "^5.0.0",
+    "pify": "^4.0.0",
+    "uncss": "^0.16.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-github-markdown-css",
-  "version": "3.0.0",
+  "version": "2.2.0",
   "description": "Generate the CSS for github-markdown-css",
   "license": "MIT",
   "repository": "sindresorhus/generate-github-markdown-css",


### PR DESCRIPTION
A normal render won't generate code snippets, so go through the API instead.  This also avoids pulling in
all kinds of styles that relate only to the link anchors supplied by the GitHub site, but not part of the
markdown render proper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sindresorhus/generate-github-markdown-css/5)
<!-- Reviewable:end -->
