### PR TITLE
Support all GitHub themes

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,10 +7,13 @@ const cli = meow(`
 	  github-markdown-css > <filename>
 
 	Options
-	  --type      Theme name: 'light', 'dark', 'auto' or other --list values.
-	              'auto' means using the media query (prefers-color-scheme)
-	              to switch between the 'light' and 'dark' theme.
-	  --list      List available themes.
+	  --theme, -t     Theme name: 'light', 'dark', 'all' or other --list values.
+	              	  The media query (prefers-color-scheme) is available
+	              	  to switch between all the differents themes chosen.
+	  --list      	  List available themes.
+	  --defaultTheme  Omit the media query (prefers-color-scheme) when using a single theme.
+	  --help      	  Show help.
+	  --version   	  Show version.
 
 	Examples
 	  $ github-markdown-css --list
@@ -20,27 +23,28 @@ const cli = meow(`
 	  dark_high_contrast
 	  dark_colorblind
 	  light_colorblind
+
+	  $ github-markdown-css -t light -t dark > example.css
 `, {
 	importMeta: import.meta,
 	flags: {
-		type: {
+		theme: {
 			type: 'string',
+			alias: 't',
+			default: ['light'],
+			isMultiple: true,
 		},
 		list: {
+			type: 'boolean',
+		},
+		defaultTheme: {
 			type: 'boolean',
 		},
 	},
 });
 
 (async () => {
-	const {type, list} = cli.flags;
+	const {theme, list, defaultTheme} = cli.flags;
 
-	let light = type;
-	let dark = type;
-	if (type === 'auto') {
-		light = 'light';
-		dark = 'dark';
-	}
-
-	console.log(await githubMarkdownCss({light, dark, list}));
+	console.log(await githubMarkdownCss({themes: theme, list, defaultTheme}));
 })();

--- a/readme.md
+++ b/readme.md
@@ -28,21 +28,26 @@ $ npm install --global generate-github-markdown-css
 ```
 $ github-markdown-css --help
 
-  Usage
-    github-markdown-css > <filename>
+	Usage
+	  github-markdown-css > <filename>
 
-  Options
-    --type      Theme name: 'light', 'dark', 'auto' or other --list values.
-                'auto' means using the media query (prefers-color-scheme)
-                to switch between the 'light' and 'dark' theme.
-    --list      List available themes.
+	Options
+	  --theme, -t     Theme name: 'light', 'dark', 'all' or other --list values.
+	              	  The media query (prefers-color-scheme) is available
+	              	  to switch between all the differents themes chosen.
+	  --list      	  List available themes.
+	  --defaultTheme  Omit the media query (prefers-color-scheme) when using a single theme.
+	  --help      	  Show help.
+	  --version   	  Show version.
 
-  Examples
-    $ github-markdown-css --list
-    light
-    dark
-    dark_dimmed
-    dark_high_contrast
-    dark_colorblind
-    light_colorblind
+	Examples
+	  $ github-markdown-css --list
+	  light
+	  dark
+	  dark_dimmed
+	  dark_high_contrast
+	  dark_colorblind
+	  light_colorblind
+
+	  $ github-markdown-css -t light -t dark > example.css
 ```

--- a/test.js
+++ b/test.js
@@ -5,9 +5,24 @@ import githubMarkdownCss from './index.js';
 (async () => {
 	fs.mkdirSync('dist', {recursive: true});
 
-	fs.writeFileSync('dist/auto.css', await githubMarkdownCss());
-	fs.writeFileSync('dist/light.css', await githubMarkdownCss({dark: 'light'}));
-	fs.writeFileSync('dist/dark.css', await githubMarkdownCss({light: 'dark'}));
+	const themes = (await githubMarkdownCss({list: true})).split('\n');
+
+	fs.writeFileSync('dist/all.css', await githubMarkdownCss());
+
+	const promises = [];
+
+	for (const theme of themes) {
+		promises.push(new Promise((resolve, reject) => {
+			githubMarkdownCss({themes: [theme]})
+				.then(css => {
+					fs.writeFileSync(`dist/${theme}.css`, css);
+					resolve();
+				})
+				.catch(reject);
+		}));
+	}
+
+	Promise.all(promises);
 
 	const fixture = await renderMarkdown();
 	const html = `<!DOCTYPE html>
@@ -16,16 +31,15 @@ import githubMarkdownCss from './index.js';
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
 <title>GitHub Markdown CSS demo</title>
-<link id="theme" rel="stylesheet" href="auto.css">
+<link id="theme" rel="stylesheet" href="all.css">
 <body class="markdown-body">
 <article class="markdown-body" style="padding: 1em; max-width: 42em; margin: 0px auto;">
 ${fixture}
 </article>
 <select style="position: fixed; top: 1em; right: 1em; font-size: 16px;"
 				onchange="theme.href=this.value">
-	<option value="auto.css">auto</option>
-	<option value="light.css">light</option>
-	<option value="dark.css">dark</option>
+	<option value="all.css">all</option>
+	${themes.map(theme => `<option value="${theme}.css">${theme}</option>`).join('\n')}
 </select>
 </body>
 </html>


### PR DESCRIPTION
Hello,

I wanted to use your library, but it was missing a lot of GitHub theme. I decided to edit your work to support all current (and future) themes provided by GitHub (for the markdown). I let you see what I have done.

Here a snippet of my work: 
https://gyazo.com/556bb260ce12f954610a78365800bd11 

If you are happy of my work, I want to add next an option to output minified CSS :)