### PR TITLE
Fix HTML syntax

### DIFF
--- a/fixture.md
+++ b/fixture.md
@@ -44,7 +44,7 @@ PLEASE DO NOT EDIT THIS PAGE! You can play around with Markdown on our [live dem
 [Line Breaks](#lines)
 [Youtube videos](#videos)
 
-<a name="headers"/>
+<a name="headers"></a>
 ## Headers
 
 ```no-highlight
@@ -79,7 +79,7 @@ Alt-H1
 Alt-H2
 ------
 
-<a name="emphasis"/>
+<a name="emphasis"></a>
 ## Emphasis
 
 ```no-highlight
@@ -101,7 +101,7 @@ Combined emphasis with **asterisks and _underscores_**.
 Strikethrough uses two tildes. ~~Scratch this.~~
 
 
-<a name="lists"/>
+<a name="lists"></a>
 ## Lists
 
 (In this example, leading and trailing spaces are shown with with dots: ⋅)
@@ -205,7 +205,7 @@ To reboot your computer, press <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>del</kbd>.
 
 
 
-<a name="links"/>
+<a name="links"></a>
 ## Links
 
 There are two ways to create links.
@@ -248,7 +248,7 @@ Some text to show that the reference links can follow later.
 [1]: http://slashdot.org
 [link text itself]: http://www.reddit.com
 
-<a name="images"/>
+<a name="images"></a>
 ## Images
 
 ```no-highlight
@@ -273,7 +273,7 @@ Reference-style:
 
 [logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
 
-<a name="code"/>
+<a name="code"></a>
 ## Code and Syntax Highlighting
 
 Code blocks are part of the Markdown spec, but syntax highlighting isn't. However, many renderers -- like Github's and *Markdown Here* -- support syntax highlighting. Which languages are supported and how those language names should be written will vary from renderer to renderer. *Markdown Here* supports highlighting for dozens of languages (and not-really-languages, like diffs and HTTP headers); to see the complete list, and how to write the language names, see the [highlight.js demo page](http://softwaremaniacs.org/media/soft/highlight/test.html).
@@ -320,7 +320,7 @@ But let's throw in a <b>tag</b>.
 ```
 
 
-<a name="tables"/>
+<a name="tables"></a>
 ## Tables
 
 Tables aren't part of the core Markdown spec, but they are part of GFM and *Markdown Here* supports them. They are an easy way of adding tables to your email -- a task that would otherwise require copy-pasting from another application.
@@ -357,7 +357,7 @@ Markdown | Less | Pretty
 *Still* | `renders` | **nicely**
 1 | 2 | 3
 
-<a name="blockquotes"/>
+<a name="blockquotes"></a>
 ## Blockquotes
 
 ```no-highlight
@@ -376,7 +376,7 @@ Quote break.
 
 > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
 
-<a name="html"/>
+<a name="html"></a>
 ## Inline HTML
 
 You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
@@ -399,7 +399,7 @@ You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
 	<dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
 </dl>
 
-<a name="hr"/>
+<a name="hr"></a>
 ## Horizontal Rule
 
 ```
@@ -432,7 +432,7 @@ ___
 
 Underscores
 
-<a name="lines"/>
+<a name="lines"></a>
 ## Line Breaks
 
 My basic recommendation for learning how line breaks work is to experiment and discover -- hit &lt;Enter&gt; once (i.e., insert one newline), then hit it twice (i.e., insert two newlines), see what happens. You'll soon learn to get what you want. "Markdown Toggle" is your friend.
@@ -457,7 +457,7 @@ This line is only separated by a single newline, so it's a separate line in the 
 
 (Technical note: *Markdown Here* uses GFM line breaks, so there's no need to use MD's two-space line breaks.)
 
-<a name="videos"/>
+<a name="videos"></a>
 ## Youtube videos
 
 They can't be added directly but you can add an image with a link to the video like this:


### PR DESCRIPTION
The current fixture includes some “anchors”, as in, named links.
They use an invalid XML-like syntax, which in HTML causes the links to run for a long while longer than they are supposed to go (often, until the next `a` element).
This fixes that, by properly closing `<a>` elements.

For more information on “straddling”, see https://html.spec.whatwg.org/multipage/dom.html#paragraphs. It’s really weird.