### PR TITLE
Delete unused data attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,6 +128,10 @@ function extractStyles(styles, ast) {
 				return false;
 			}
 
+			if (selector.includes('[data-') && !selector.includes('[data-color-mode')) {
+				return false;
+			}
+
 			const tag = selector.match(/^\w[-\w]+/);
 			if (tag && !ALLOW_TAGS.has(tag[0])) {
 				return false;
@@ -154,6 +158,10 @@ function extractStyles(styles, ast) {
 			return selector.slice(5);
 		}
 
+		if (selector.startsWith(':root ')) {
+			return selector.slice(6);
+		}
+
 		return selector;
 	}
 
@@ -174,7 +182,7 @@ function extractStyles(styles, ast) {
 function classifyRules(rules) {
 	function extractTheme(rule) {
 		for (const selector of rule.selectors) {
-			const match = /-theme\*=(\w+)/.exec(selector);
+			const match = /(?:-theme\*|data-color-mode)=(\w+)/.exec(selector);
 			if (match) {
 				return match[1];
 			}


### PR DESCRIPTION
https://github.com/sindresorhus/generate-github-markdown-css/pull/18#issuecomment-1424029327

This PR removes rules with `[data-xxx]` selectors, they are often unused and have no effect on markdown body. Note that `[data-color-mode]` are preserved because they can be used to extract theme variables.

Quick commands to view generated css diff:

```console
# generate dist/auto.css
node test

# fetch latest github-markdown.css
curl -O https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.css
# or fetch mine, it was generated from some newer github css
curl -O https://cdn.jsdelivr.net/npm/@hyrious/github-markdown-css/github-markdown.css

# diff
git diff --no-index github-markdown.css dist/auto.css
```

