### PR TITLE
Expand functionality to better support theme variable exports

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,46 +1,138 @@
 #!/usr/bin/env node
+import {exit} from 'node:process';
 import meow from 'meow';
 import githubMarkdownCss from './index.js';
 
-const cli = meow(`
-	Usage
-	  github-markdown-css > <filename>
+const cli = meow(
+	`
+  Usage
+    github-markdown-css > <filename>
 
-	Options
-	  --type      Theme name: 'light', 'dark', 'auto' or other --list values.
-	              'auto' means using the media query (prefers-color-scheme)
-	              to switch between the 'light' and 'dark' theme.
-	  --list      List available themes.
+  Options
+    --list            List available themes
 
-	Examples
-	  $ github-markdown-css --list
-	  light
-	  dark
-	  dark_dimmed
-	  dark_high_contrast
-	  dark_colorblind
-	  light_colorblind
-`, {
-	importMeta: import.meta,
-	flags: {
-		type: {
-			type: 'string',
-		},
-		list: {
-			type: 'boolean',
+    Set theme:
+      -l, --light           Light theme name from --list values
+      -d, --dark            Dark theme name from --list values
+      -t, --type, --theme   Theme name: 'auto', light', 'dark', or another from --list values.
+                            'auto' means using the media query (prefers-color-scheme)
+                            to switch between the 'light' and 'dark' theme.
+
+    Output options:
+      --preserveVars        Preserve variables in the output. Only applies if light
+                            and dark themes match or if type is not 'auto'
+      --onlyStyle           Only output the styles, forces preserveVars on
+      --onlyVars            Only output the variables for the specified themes
+      --rootSelector        Specify the root selector when outputting styles, default '.markdown-body'
+
+  Examples
+    $ github-markdown-css --list
+    light
+    dark
+    dark_dimmed
+    dark_high_contrast
+    dark_colorblind
+    light_colorblind
+
+    $ github-markdown-css --light=light --dark=dark
+    [CSS with variable blocks for 'light' and 'dark' themes]
+
+    $ github-markdown-css --theme=dark_dimmed --onlyVars
+    [CSS with single variable block for 'dark_dimmed' theme with no element styles]
+
+    $ github-markdown-css --onlyStyles
+    [CSS with only element styles using variables but no variables set.
+      Use in combination with output from setting --onlyVars]
+`,
+	{
+		importMeta: import.meta,
+		flags: {
+			theme: {
+				alias: ['t', 'type'],
+				type: 'string',
+			},
+			light: {
+				alias: 'l',
+				type: 'string',
+			},
+			dark: {
+				alias: 'd',
+				type: 'string',
+			},
+			list: {
+				type: 'boolean',
+			},
+			onlyStyle: {
+				type: 'boolean',
+			},
+			onlyVars: {
+				type: 'boolean',
+			},
+			preserveVars: {
+				type: 'boolean',
+			},
+			rootSelector: {
+				type: 'string',
+			},
 		},
 	},
-});
+);
 
 (async () => {
-	const {type, list} = cli.flags;
+	const {theme, list, preserveVars, onlyStyle, onlyVars, rootSelector} = cli.flags;
+	let {light, dark} = cli.flags;
 
-	let light = type;
-	let dark = type;
-	if (type === 'auto') {
-		light = 'light';
-		dark = 'dark';
+	/*
+	 * | Theme | Light | Dark | Outcome                            |
+	 * | ----- | ----- | ---- | ---------------------------------- |
+	 * | ✓     |       |      | Single mode, use Theme             |
+	 * | ✓     | ✓     |      | Not allowed, can't determine theme |
+	 * | ✓     |       | ✓    | Not allowed, can't determine theme |
+	 * | ✓     | ✓     | ✓    | Not allowed, can't determine theme |
+	 * |       |       |      | Auto, default themes               |
+	 * |       | ✓     |      | Single mode, use Light             |
+	 * |       |       | ✓    | Single mode, use Dark              |
+	 * |       | ✓     | ✓    | Auto, use Light and Dark           |
+	 * |       | ✓     | ✓    | Single mode if Light === Dark      |
+	 * | auto  |       |      | Auto, default themes               |
+	 * | auto  | ✓     |      | Auto, use Light, default dark      |
+	 * | auto  |       | ✓    | Auto, use Dark, default light      |
+	 * | auto  | ✓     | ✓    | Auto, use Light and Dark           |
+	 * | auto  | ✓     | ✓    | Single mode if Light === Dark      |
+	 */
+
+	// Use "single" mode when type is a theme name other than 'auto'
+	if (theme && theme !== 'auto') {
+		if (light || dark) {
+			console.error('You may not specify light and/or dark unless type/theme is set to "auto"');
+			exit(1);
+		}
+
+		light = theme;
+		dark = theme;
 	}
 
-	console.log(await githubMarkdownCss({light, dark, list}));
+	// If only light or dark was specified set the other to force "single mode"
+	if (!theme && light && !dark) {
+		dark = light;
+	} else if (!theme && !light && dark) {
+		light = dark;
+	}
+
+	if (rootSelector === '') {
+		console.error('--rootSelector cannot be an empty string');
+		exit(1);
+	}
+
+	console.log(
+		await githubMarkdownCss({
+			light,
+			dark,
+			list,
+			preserveVariables: preserveVars,
+			onlyStyles: onlyStyle,
+			onlyVariables: onlyVars,
+			rootSelector,
+		}),
+	);
 })();

--- a/readme.md
+++ b/readme.md
@@ -13,9 +13,44 @@ First the GitHub.com CSS is fetched. Then we walk through all rules that could t
 ## API
 
 ```js
-import githubMarkdownCss from 'generate-github-markdown-css';
+import githubMarkdownCss from "generate-github-markdown-css";
 
-console.log(await githubMarkdownCss({ light: 'light', dark: 'dark' }));
+/*
+ * If the `light` and `dark` themes are different the CSS returned will include
+ * `prefers-color-scheme` blocks for light and dark that match the specified
+ * `light` and `dark` themes (considered "auto" mode). This mode will always
+ * `preserveVars` as they are necessary for the `prefers-color-scheme` blocks
+ *
+ * If the `light` and `dark` themes are equal the output will only contain one
+ * theme (considered "single" mode)
+ *
+ * In "single" mode the output will apply the values of all variables to the
+ * rules themselves.The output will not contain any `var(--variable)` statements.
+ * You can disable this by setting `preserveVariables` to true
+ */
+
+console.log(await githubMarkdownCss({
+    // The theme to use for light theme
+    light: "light",
+    // The theme to use for dark theme
+    dark: "dark",
+    // If `true` will return a list of available themes instead of the CSS
+    list = false,
+    // If `true` will preserve the block of variables for a given theme even if
+    // only exporting one theme. By default variables are applied to the rules
+    // themselves and the resulting CSS will not contain any `var(--variable)`
+    preserveVariables = false,
+    // Only output the color variables part of the css. forces
+    // `preserveVariables` to be `true`
+    onlyVariables = false,
+    // Only output the style part of the css without any variables. forces
+    // `preserveVariables` to be `true` and ignores the theme values.
+    // Useful to get the base styles to use multiple themes
+    onlyStyles = false,
+    // Set the root selector of the rendered markdown body as it should appear
+    // in the output css. Defaults to `.markdown-body`
+    rootSelector = '.markdown-body',
+  }));
 //=> '.markdown-body { …'
 ```
 
@@ -32,10 +67,21 @@ $ github-markdown-css --help
     github-markdown-css > <filename>
 
   Options
-    --type      Theme name: 'light', 'dark', 'auto' or other --list values.
-                'auto' means using the media query (prefers-color-scheme)
-                to switch between the 'light' and 'dark' theme.
-    --list      List available themes.
+    --list            List available themes
+
+    Set theme:
+      -l, --light           Light theme name from --list values
+      -d, --dark            Dark theme name from --list values
+      -t, --type, --theme   Theme name: 'auto', light', 'dark', or another from --list values.
+                            'auto' means using the media query (prefers-color-scheme)
+                            to switch between the 'light' and 'dark' theme.
+
+    Output options:
+      --preserveVars        Preserve variables in the output. Only applies if light
+                            and dark themes match or if type is not 'auto'
+      --onlyStyle           Only output the styles, forces preserveVars on
+      --onlyVars            Only output the variables for the specified themes
+      --rootSelector        Specify the root selector when outputting styles, default '.markdown-body'
 
   Examples
     $ github-markdown-css --list
@@ -45,4 +91,14 @@ $ github-markdown-css --help
     dark_high_contrast
     dark_colorblind
     light_colorblind
+
+    $ github-markdown-css --light=light --dark=dark
+    [CSS with variable blocks for 'light' and 'dark' themes]
+
+    $ github-markdown-css --theme=dark_dimmed --onlyVars
+    [CSS with single variable block for 'dark_dimmed' theme with no element styles]
+
+    $ github-markdown-css --onlyStyles
+    [CSS with only element styles using variables but no variables set.
+      Use in combination with output from setting --onlyVars]
 ```

--- a/test.js
+++ b/test.js
@@ -6,8 +6,22 @@ import githubMarkdownCss from './index.js';
 	fs.mkdirSync('dist', {recursive: true});
 
 	fs.writeFileSync('dist/auto.css', await githubMarkdownCss());
-	fs.writeFileSync('dist/light.css', await githubMarkdownCss({dark: 'light'}));
-	fs.writeFileSync('dist/dark.css', await githubMarkdownCss({light: 'dark'}));
+	const themes = [
+		'light',
+		'light_high_contrast',
+		'light_colorblind',
+		'light_tritanopia',
+		'dark',
+		'dark_high_contrast',
+		'dark_colorblind',
+		'dark_tritanopia',
+		'dark_dimmed',
+	];
+
+	await Promise.all(themes.map(async theme => {
+		fs.writeFileSync(`dist/${theme}.css`, await githubMarkdownCss({light: theme, dark: theme}));
+	}));
+	fs.writeFileSync('dist/auto_colorblind.css', await githubMarkdownCss({light: 'light_colorblind', dark: 'dark_colorblind'}));
 
 	const fixture = await renderMarkdown();
 	const html = `<!DOCTYPE html>
@@ -24,11 +38,44 @@ ${fixture}
 <select style="position: fixed; top: 1em; right: 1em; font-size: 16px;"
 				onchange="theme.href=this.value">
 	<option value="auto.css">auto</option>
-	<option value="light.css">light</option>
-	<option value="dark.css">dark</option>
+	<option value="auto_colorblind.css">auto_colorblind</option>
+	${themes.map(theme => `<option value="${theme}.css">${theme}</option>`).join('\n')}
 </select>
 </body>
 </html>
 `;
 	fs.writeFileSync('dist/index.html', html);
+
+	// Demonstrate theme variable files switching with base css
+	fs.mkdirSync('dist/vars', {recursive: true});
+
+	fs.writeFileSync('dist/vars/base.css', await githubMarkdownCss({onlyStyles: true}));
+	fs.writeFileSync('dist/vars/auto-vars.css', await githubMarkdownCss({onlyVariables: true}));
+	fs.writeFileSync('dist/vars/auto_colorblind-vars.css', await githubMarkdownCss({light: 'light_colorblind', dark: 'dark_colorblind', onlyVariables: true}));
+	await Promise.all(themes.map(async theme => {
+		fs.writeFileSync(`dist/vars/${theme}-vars.css`, await githubMarkdownCss({light: theme, dark: theme, onlyVariables: true}));
+	}));
+
+	const htmlVars = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
+<title>GitHub Markdown CSS demo</title>
+<link id="base" rel="stylesheet" href="base.css">
+<link id="theme" rel="stylesheet" href="auto-vars.css">
+<body class="markdown-body">
+<article class="markdown-body" style="padding: 1em; max-width: 42em; margin: 0px auto;">
+${fixture}
+</article>
+<select style="position: fixed; top: 1em; right: 1em; font-size: 16px;"
+				onchange="theme.href=this.value">
+	<option value="auto-vars.css">auto</option>
+	<option value="auto_colorblind-vars.css">auto_colorblind</option>
+	${themes.map(theme => `<option value="${theme}-vars.css">${theme}</option>`).join('\n')}
+</select>
+</body>
+</html>
+`;
+	fs.writeFileSync('dist/vars/index.html', htmlVars);
 })();


### PR DESCRIPTION
### Background

I was starting to try and tackle adding better support for all of GitHub's themes in the VSCode [GitHub Markdown preview extension](https://github.com/mjbvz/vscode-github-markdown-preview-style). Namely this issue: https://github.com/mjbvz/vscode-github-markdown-preview-style/issues/89. That lead me to realize it'd be easiest if I could export each of the theme's color variables by themselves to allow easier swapping between them. Looking into this tool I there wasn't a way to easily export the theme variables by themselves because of the `applyColors` function when in "single" mode. This whole change started as a way to add an option around that.

### Summary

- Added an option to preserve variables in output even when outputting a single theme, `preserveVariables`
- Added an option to _only_ output variables, `onlyVariables`
- Added an option to _only_ output the styles without variables to be used alongside the variable only files, `onlyStyles`
- Added an option to change the root selector used in the output to whatever people want, `rootSelector`
  - I did this because I noticed the extension [changed](https://github.com/mjbvz/vscode-github-markdown-preview-style/commit/d6ec1d9b58c754e4060b8dbdf660df53a26505f0) it to `.github-markdown-body` and it's easy to do in the source of the files here instead of a manual process. This also allows any consuming systems to easily set their own root class if they want. this probably should've been a separate PR though...
- Added a JSDoc block for the primary `getCSS` API method, including the new options, to make it easier for consumers to use without digging into the code
- Added comments to the CSS output including what theme was exported
  - In single mode this is at the top of the file, in auto mode this is included inside the `prefers-color-scheme` blocks.
- Added `[data-theme="THEME"]` selectors to the theme blocks when exporting any variable blocks
  - The goal was to help make it easier for any consumers to allow easy theme changing by changing the data on the root element but this also probably could've been a separate PR
- Expanded test file generation to include all current themes and include exports for the variable only method to demonstrate using those files together
- Expanded the CLI to support all the new options I added as well as various combinations in auto mode
- Added some input validation for the CLI and the API method
- Updated the [README](https://github.com/jjspace/generate-github-markdown-css/blob/5fca17e82eb32f3568d7e874f5c6c260bb41e8e7/readme.md) to portray all my changes

Throughout my changes I aimed to preserve the existing behavior for both the CLI and the API method. All existing calls to the function should behave as they used to and all calls to the CLI version should output the same results. I wanted to _expand_ the functionality not change it.

I will admit the changes started to expand in scope quickly as I got into the flow of working on this so if it's better to break into multiple PRs or remove some of them I'd totally understand.

### Testing

- Run `npm test`
- Open `dist/index.html` and cycle through all the options in the upper right
- Verify the css files under `dist/` look correct
- Open `dist/vars/index.html` and cycle through all the options in the upper right
- Verify the css files under `dist/vars` look correct and that they only include the color variables
  - Verify the `dist/vars/base.css` includes all the styles with `var(--variable)` statements but no colors