### PR TITLE
Add support for alerts

### DIFF
--- a/fixture.md
+++ b/fixture.md
@@ -11,6 +11,16 @@
 
 <img src="image.png" width="182" align="right">
 
+#### Alerts
+
+> [!NOTE]
+> Highlights information that users should take into account, even when skimming.
+
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+> [!WARNING]
+> Critical content demanding immediate user attention due to potential risks.
 
 ### Code snippet
 

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ const ALLOW_CLASS = new Set([
 	'.contains-task-list',
 	'.task-list-item',
 	'.task-list-item-checkbox',
-	// For markdown alerts
+	// For Markdown alerts.
 	'.markdown-alert',
 	'.color-fg-accent',
 	'.color-fg-attention',

--- a/index.js
+++ b/index.js
@@ -111,6 +111,15 @@ const ALLOW_CLASS = new Set([
 	'.contains-task-list',
 	'.task-list-item',
 	'.task-list-item-checkbox',
+	// For markdown alerts
+	'.markdown-alert',
+	'.color-fg-accent',
+	'.color-fg-attention',
+	'.color-fg-done',
+	'.text-semibold',
+	'.d-inline-flex',
+	'.flex-items-center',
+	'.mb-1',
 ]);
 
 function extractStyles(rules, ast) {


### PR DESCRIPTION
#### Description
Adds support for the following markdown alerts. Works great with [marked-alert](https://www.npmjs.com/package/marked-alert).

#### Example

```markdown
> [!NOTE]  
> Highlights information that users should take into account, even when skimming.

> [!IMPORTANT]  
> Crucial information necessary for users to succeed.

> [!WARNING]  
> Critical content demanding immediate user attention due to potential risks.
```

> [!NOTE]  
> Highlights information that users should take into account, even when skimming.

> [!IMPORTANT]  
> Crucial information necessary for users to succeed.

> [!WARNING]  
> Critical content demanding immediate user attention due to potential risks.

#### Issues

The alerts in the fixture aren't being rendered correctly by GitHub's markdown endpoint. Maybe it hasn't been updated yet? I've used the rendered alerts here to find the right classes to add to the allow list.