### PR TITLE
Fix workaround with GitHub latest styles

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,7 +23,7 @@ const cli = meow(
                            and dark themes match or if type is not 'auto'
     --only-style           Only output the styles, forces --preserve-variables on
     --only-variables       Only output the variables for the specified themes
-    --rootSelector         Specify the root selector when outputting styles, default '.markdown-body'
+    --root-selector        Specify the root selector when outputting styles, default '.markdown-body'
 
   Examples
     $ github-markdown-css --list
@@ -40,7 +40,7 @@ const cli = meow(
     $ github-markdown-css --theme=dark_dimmed --only-variables
     [CSS with single variable block for 'dark_dimmed' theme with no element styles]
 
-    $ github-markdown-css --onlyStyles
+    $ github-markdown-css --only-style
     [CSS with only element styles using variables but no variables set.
       Use in combination with output from setting --only-variables]
 `,

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ $ github-markdown-css --help
                            and dark themes match or if type is not 'auto'
     --only-style           Only output the styles, forces --preserve-variables on
     --only-variables       Only output the variables for the specified themes
-    --rootSelector         Specify the root selector when outputting styles, default '.markdown-body'
+    --root-selector        Specify the root selector when outputting styles, default '.markdown-body'
 
   Examples
     $ github-markdown-css --list
@@ -93,7 +93,7 @@ $ github-markdown-css --help
     $ github-markdown-css --theme=dark_dimmed --only-variables
     [CSS with single variable block for 'dark_dimmed' theme with no element styles]
 
-    $ github-markdown-css --onlyStyles
+    $ github-markdown-css --only-style
     [CSS with only element styles using variables but no variables set.
       Use in combination with output from setting --only-variables]
 ```


### PR DESCRIPTION
This PR did various changes to make it work with the latest styles from GitHub.

- Fixed an oversight in previous versions where auto.css includes duplicated CSS variables. See the `light` section here: https://cdn.jsdelivr.net/npm/github-markdown-css@5.4.0/github-markdown.css
- Refactored works from #26 to match the latest alert structures:
  ```html
  <div class="markdown-alert markdown-alert-note" dir="auto">
    <p class="markdown-alert-title" dir="auto">
      <svg class="octicon octicon-info mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>
      Note
    </p>
    <p dir="auto">Highlights information that users should take into account, even when skimming.</p>
  </div>
  ```
  Which means it now adds classes like `markdown-alert-note` `markdown-alert-title` `octicon-info` `mr-2` to the ALLOW_CLASS set.
- Refactored ALLOW_TAGS to match the latest sanitizer's code.
- Workaround new CSS syntax `@container` to make it able to parse GitHub CSS again.

To read the output diff:

```console
$ node test
$ wget https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.css
$ git diff --no-index github-markdown.css dist/auto.css
```

Next steps:

As I mentioned in #27, GitHub will use newer CSS syntaxes from now on -- they are using `@container`, maybe the next is `@layer` or even CSS nestings. We need not a workaround but a solution to parse these new CSS syntaxes. Maybe integrating [lightningcss](https://lightningcss.dev/), or making a fork of the `css` module to add supports (it is not updated for 2 years).