### PR TITLE
Fix `--base-size-4` variable is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function extractColors(colors, name, ast) {
 		colors[name][property] = value;
 	}
 
+	addDeclaration('--base-size-4', '4px');
 	addDeclaration('--base-size-8', '8px');
 	addDeclaration('--base-size-16', '16px');
 	addDeclaration('--base-text-weight-normal', '400');


### PR DESCRIPTION
`--base-size-4` variable is used in the style for task lists:

```css
.markdown-body .task-list-item+.task-list-item {
  margin-top: var(--base-size-4);
}
```

but the variable is not defined. This PR fixes the issue.