### PR TITLE
Define shared theme variables once

### DIFF
--- a/index.js
+++ b/index.js
@@ -482,6 +482,12 @@ export default async function getCSS({
 						...filterColors(colors[light], usedVariables),
 					],
 				});
+
+				rules.unshift({
+					type: 'rule',
+					selectors: ['.markdown-body'],
+					declarations: sharedDeclarations,
+				});
 			} else {
 				rules = applyColors(colors[light], rules);
 
@@ -522,13 +528,13 @@ export default async function getCSS({
 					],
 				}],
 			});
-		}
 
-		rules.unshift({
-			type: 'rule',
-			selectors: ['.markdown-body'],
-			declarations: sharedDeclarations,
-		});
+			rules.unshift({
+				type: 'rule',
+				selectors: ['.markdown-body'],
+				declarations: sharedDeclarations,
+			});
+		}
 	}
 
 	let string = css.stringify({type: 'stylesheet', stylesheet: {rules}});

--- a/index.js
+++ b/index.js
@@ -434,19 +434,6 @@ export default async function getCSS({
 		return colors.map(({name}) => name).join('\n');
 	}
 
-	// Merge shared variables into every color theme
-	for (const declarations of shared) {
-		for (const declaration of declarations) {
-			const {property, value} = declaration;
-			for (const theme of colors) {
-				if (!(property in theme)) {
-					theme[property] = value;
-					theme.unshift(declaration);
-				}
-			}
-		}
-	}
-
 	rules = reverseUnique(rules, rule => {
 		const selector = rule.selectors.join(',');
 		const body = rule.declarations.map(({property, value}) => `${property}: ${value}`).join(';');
@@ -531,6 +518,12 @@ export default async function getCSS({
 				}],
 			});
 		}
+
+		rules.unshift({
+			type: 'rule',
+			selectors: ['.markdown-body'],
+			declarations: filterColors(shared.flat(1), usedVariables),
+		});
 	}
 
 	let string = css.stringify({type: 'stylesheet', stylesheet: {rules}});

--- a/index.js
+++ b/index.js
@@ -468,6 +468,8 @@ export default async function getCSS({
 	}
 
 	if (!onlyStyles) {
+		const sharedDeclarations = filterColors(shared.flat(1), usedVariables);
+
 		if (light === dark) {
 			if (preserveVariables) {
 				rules.unshift({
@@ -482,6 +484,9 @@ export default async function getCSS({
 				});
 			} else {
 				rules = applyColors(colors[light], rules);
+
+				const sharedColors = Object.fromEntries(sharedDeclarations.map(({property, value}) => [property, value]));
+				rules = applyColors(sharedColors, rules);
 
 				if (light.startsWith('dark')) {
 					rules[0].declarations.unshift(colorSchemeDark);
@@ -522,7 +527,7 @@ export default async function getCSS({
 		rules.unshift({
 			type: 'rule',
 			selectors: ['.markdown-body'],
-			declarations: filterColors(shared.flat(1), usedVariables),
+			declarations: sharedDeclarations,
 		});
 	}
 


### PR DESCRIPTION
These variables are defined in both light mode and dark mode. So they can be defined unconditionally.

```css
--fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
--base-text-weight-semibold: 600;
--base-text-weight-medium: 500;
--base-text-weight-normal: 400;
--base-size-16: 1rem;
--base-size-8: 0.5rem;
--base-size-4: 0.25rem;
```

This PR defines these variables once instead of defining them in respective modes so that we can reduce the size of output.

Here is the diff of the output before/after applying this PR:

```diff
--- test.css	2024-06-15 09:53:59.169379660 +0900
+++ test2.css	2024-06-15 10:08:38.183798342 +0900
@@ -1,15 +1,18 @@
+.markdown-body {
+  --base-size-4: 0.25rem;
+  --base-size-8: 0.5rem;
+  --base-size-16: 1rem;
+  --base-text-weight-normal: 400;
+  --base-text-weight-medium: 500;
+  --base-text-weight-semibold: 600;
+  --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+}
+
 @media (prefers-color-scheme: dark) {
   .markdown-body,
   [data-theme="dark"] {
     /*dark*/
     color-scheme: dark;
-    --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
-    --base-text-weight-semibold: 600;
-    --base-text-weight-medium: 500;
-    --base-text-weight-normal: 400;
-    --base-size-16: 1rem;
-    --base-size-8: 0.5rem;
-    --base-size-4: 0.25rem;
     --focus-outlineColor: #1f6feb;
     --fgColor-default: #e6edf3;
     --fgColor-muted: #8d96a0;
@@ -68,13 +71,6 @@
   [data-theme="light"] {
     /*light*/
     color-scheme: light;
-    --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
-    --base-text-weight-semibold: 600;
-    --base-text-weight-medium: 500;
-    --base-text-weight-normal: 400;
-    --base-size-16: 1rem;
-    --base-size-8: 0.5rem;
-    --base-size-4: 0.25rem;
     --focus-outlineColor: #0969da;
     --fgColor-default: #1f2328;
     --fgColor-muted: #636c76;
```

